### PR TITLE
0.x1..xl notation, some i missing, the nth qbit get multiplied by theta_n

### DIFF
--- a/vignettes/addbyqft.Rmd
+++ b/vignettes/addbyqft.Rmd
@@ -44,7 +44,7 @@ x = x_1 2^0 + x_2 2^1 + \ldots + x_n 2^{n-1}
 \]
 and
 \[
-0.x_1 \ldots x_l\ \equiv\ \frac{x_l}{2^l} + \frac{x_{l-1}}{2^{l-1}} + \ldots + \frac{x_1}{2^{1}}\,.
+0.x_1 \ldots x_l\ \equiv\ \frac{x_l}{2} + \frac{x_{l-1}}{2^{2}} + \ldots + \frac{x_1}{2^{l}}\,.
 \]
 Now, we apply a phase shift $R_\theta(\theta)$ to each qubit
 \[
@@ -68,14 +68,14 @@ Since $\exp(2\pi i y_k l) = 1$ for positive integer $l$, this reduces to
 \exp(2\pi i y/2^{n-j+1-1}) = \prod_{k=0}^{n-j-1} \exp(2\pi i y_{k+1} 2^{j-n+k})\,.
 \]
 The $n$th qubit gets multiplied with $\exp(i\theta_n)$ with 
-$\theta_1 = 2\pi y 2^{0}$. Thus, we need to compute
+$\theta_n = 2\pi y /2^{1}$. Thus, we need to compute
 \[
-\exp(2\pi i x_1/2)\cdot \exp(2\pi y_1/2) = \exp(2\pi (x_1 + y_1) /2)\,.
+\exp(2\pi i x_1/2)\cdot \exp(2\pi i y_1/2) = \exp(2\pi i (x_1 + y_1) /2)\,.
 \]
 Similarly, one gets
 \[
-\exp(2\pi i (x_1/2 + x_2/4 + ...)\cdot \exp(2\pi (y_1/2 + y_2/4 + ...)
-= \exp(2\pi ((x_1 + y_1) /2 + (x_2 + y_2)/4 + ...)
+\exp(2\pi i (x_1/2 + x_2/4 + ...)\cdot \exp(2\pi i (y_1/2 + y_2/4 + ...)
+= \exp(2\pi i ((x_1 + y_1) /2 + (x_2 + y_2)/4 + ...))
 \]
 which implements the addition $\mod n$ operation in this binary fraction.
 


### PR DESCRIPTION
there are some "i" missing.

I think that the meaning of 0.x1..xl should be different. Since the binary representation of x is the opposite of Nielsen & Chuang I believe that also 0.x1..xl should be the opposite.